### PR TITLE
Initialize TechJoint scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# techjoint
+# TechJoint Repository
+
+This repository contains the source for the TechJoint web application. The project is located in the [`tech-joint`](tech-joint/) directory.

--- a/tech-joint/.devcontainer.json
+++ b/tech-joint/.devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "TechJoint",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/pnpm:2": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "rebornix.ruby"
+      ]
+    }
+  }
+}

--- a/tech-joint/.env.example
+++ b/tech-joint/.env.example
@@ -1,0 +1,2 @@
+# Example API key for transcription service
+VITE_TRANSCRIBE_KEY=

--- a/tech-joint/.eslintrc.cjs
+++ b/tech-joint/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'react', 'react-hooks'],
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  env: {
+    browser: true,
+    es2022: true,
+    node: true
+  }
+};

--- a/tech-joint/.github/workflows/deploy.yml
+++ b/tech-joint/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: build-test-deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/tech-joint/.gitignore
+++ b/tech-joint/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+pnpm-lock.yaml
+.env
+.DS_Store
+dist
+coverage

--- a/tech-joint/.npmrc
+++ b/tech-joint/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/tech-joint/.prettierrc
+++ b/tech-joint/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/tech-joint/CHANGELOG.md
+++ b/tech-joint/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2024-05-17
+- Initial project scaffold.

--- a/tech-joint/CONTRIBUTING.md
+++ b/tech-joint/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+Thank you for considering contributing to TechJoint!
+
+## Development Setup
+
+1. Fork the repository and clone your fork.
+2. Install dependencies with `pnpm install`.
+3. Run `pnpm dev` to start the development server.
+
+## Pull Requests
+
+Please run `pnpm lint` and `pnpm test` before submitting a pull request.

--- a/tech-joint/LICENSE
+++ b/tech-joint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tech-joint/README.md
+++ b/tech-joint/README.md
@@ -1,0 +1,12 @@
+# TechJoint
+
+TechJoint is a share link platform that hosts internal tools as clickable icons. This project uses React (TypeScript), Vite and Tailwind CSS. The app is deployed to GitHub Pages using GitHub Actions.
+
+## Development
+
+1. Install dependencies with `pnpm install`.
+2. Start the dev server with `pnpm dev`.
+
+## Deployment
+
+All pushes to `main` run the CI workflow that builds and deploys to GitHub Pages.

--- a/tech-joint/index.html
+++ b/tech-joint/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TechJoint</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/tech-joint/package.json
+++ b/tech-joint/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "tech-joint",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint -c .eslintrc.cjs src --ext ts,tsx",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.24",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.4",
+    "vitest": "^1.4.0"
+  }
+}

--- a/tech-joint/postcss.config.cjs
+++ b/tech-joint/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tech-joint/public/icons/microphone.svg
+++ b/tech-joint/public/icons/microphone.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 1v10m0 0a4 4 0 004-4V5a4 4 0 10-8 0v2a4 4 0 004 4zm0 0v4m-5 4h10" />
+</svg>

--- a/tech-joint/public/manifest.webmanifest
+++ b/tech-joint/public/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "TechJoint",
+  "short_name": "TechJoint",
+  "start_url": "/tech-joint/",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "32x32",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/tech-joint/src/App.tsx
+++ b/tech-joint/src/App.tsx
@@ -1,0 +1,14 @@
+import { Routes, Route } from 'react-router-dom';
+import Home from './routes/Home';
+import Tool from './routes/Tool';
+import NotFound from './routes/NotFound';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/tool/:id" element={<Tool />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  );
+}

--- a/tech-joint/src/components/DropZone.tsx
+++ b/tech-joint/src/components/DropZone.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+
+interface Props {
+  onUpload: (file: File) => void;
+  maxSizeMB?: number;
+  accept?: string;
+}
+
+export default function DropZone({ onUpload, maxSizeMB = 50, accept = 'audio/*' }: Props) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      if (file.size > maxSizeMB * 1024 * 1024) {
+        alert('File too large');
+        return;
+      }
+      onUpload(file);
+    },
+    [onUpload, maxSizeMB]
+  );
+
+  return <input type="file" accept={accept} onChange={handleChange} />;
+}

--- a/tech-joint/src/components/Footer.tsx
+++ b/tech-joint/src/components/Footer.tsx
@@ -1,0 +1,11 @@
+export default function Footer() {
+  return (
+    <footer className="p-4 bg-gray-100 text-center text-sm mt-8">
+      <p>
+        <a href="https://github.com" target="_blank" rel="noreferrer">
+          GitHub
+        </a>
+      </p>
+    </footer>
+  );
+}

--- a/tech-joint/src/components/Header.tsx
+++ b/tech-joint/src/components/Header.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+export default function Header() {
+  return (
+    <header className="p-4 shadow mb-4 bg-white sticky top-0">
+      <Link to="/" className="font-bold text-xl">
+        TechJoint
+      </Link>
+    </header>
+  );
+}

--- a/tech-joint/src/components/IconCard.tsx
+++ b/tech-joint/src/components/IconCard.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+
+type Props = {
+  id: string;
+  title: string;
+  icon: string;
+  href: string;
+  comingSoon?: boolean;
+};
+
+export default function IconCard({ id, title, icon, href, comingSoon }: Props) {
+  const content = (
+    <div className="flex flex-col items-center p-4 border rounded hover:bg-gray-50">
+      <img src={icon} alt={title} className="w-8 h-8 mb-2" />
+      <span>{title}</span>
+    </div>
+  );
+
+  return comingSoon ? (
+    <div>{content}</div>
+  ) : (
+    <Link to={href}>{content}</Link>
+  );
+}

--- a/tech-joint/src/components/IconGrid.tsx
+++ b/tech-joint/src/components/IconGrid.tsx
@@ -1,0 +1,12 @@
+import tools from '../data/tools';
+import IconCard from './IconCard';
+
+export default function IconGrid() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+      {tools.map((tool) => (
+        <IconCard key={tool.id} {...tool} />
+      ))}
+    </div>
+  );
+}

--- a/tech-joint/src/components/Modal.tsx
+++ b/tech-joint/src/components/Modal.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export default function Modal({ title, children, onClose }: Props) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white p-4 rounded shadow max-w-md w-full">
+        <div className="flex justify-between items-center mb-2">
+          <h2 className="text-lg font-bold">{title}</h2>
+          <button onClick={onClose}>X</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/tech-joint/src/components/Toast.tsx
+++ b/tech-joint/src/components/Toast.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  message: string;
+}
+
+export default function Toast({ message }: Props) {
+  return <div className="fixed bottom-4 right-4 bg-black text-white p-2">{message}</div>;
+}

--- a/tech-joint/src/components/TranscriptViewer.tsx
+++ b/tech-joint/src/components/TranscriptViewer.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  content: string;
+  onDownload: () => void;
+}
+
+export default function TranscriptViewer({ content, onDownload }: Props) {
+  return (
+    <div>
+      <pre className="whitespace-pre-wrap border p-2 mb-2">{content}</pre>
+      <button onClick={onDownload} className="px-2 py-1 border">Download</button>
+    </div>
+  );
+}

--- a/tech-joint/src/data/tools.ts
+++ b/tech-joint/src/data/tools.ts
@@ -1,0 +1,11 @@
+const tools = [
+  {
+    id: 'transcription',
+    title: 'Audio Transcription',
+    icon: '/icons/microphone.svg',
+    href: '/tool/transcription',
+    comingSoon: false,
+  },
+];
+
+export default tools;

--- a/tech-joint/src/lib/analytics.ts
+++ b/tech-joint/src/lib/analytics.ts
@@ -1,0 +1,3 @@
+export function track(event: string, data?: Record<string, unknown>) {
+  console.log('Tracking event', event, data);
+}

--- a/tech-joint/src/lib/designTokens.ts
+++ b/tech-joint/src/lib/designTokens.ts
@@ -1,0 +1,9 @@
+export const colors = {
+  primary: '#1E90FF',
+  primaryHover: '#1C7ED6',
+  secondary: '#0C0C0C',
+  accent: '#FFB703',
+  background: '#FFFFFF',
+  surface: '#F8F9FA',
+  error: '#D32F2F',
+};

--- a/tech-joint/src/lib/seo.ts
+++ b/tech-joint/src/lib/seo.ts
@@ -1,0 +1,6 @@
+export function getDefaultMeta() {
+  return {
+    title: 'TechJoint',
+    description: 'Internal tools as clickable icons',
+  };
+}

--- a/tech-joint/src/lib/transcribe.ts
+++ b/tech-joint/src/lib/transcribe.ts
@@ -1,0 +1,6 @@
+export async function transcribe(file: File): Promise<string> {
+  const apiKey = import.meta.env.VITE_TRANSCRIBE_KEY;
+  if (!apiKey) throw new Error('Missing API key');
+  // TODO: implement transcription API call
+  return Promise.resolve('');
+}

--- a/tech-joint/src/main.tsx
+++ b/tech-joint/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles/globals.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter basename="/tech-joint/">
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/tech-joint/src/routes/Home.tsx
+++ b/tech-joint/src/routes/Home.tsx
@@ -1,0 +1,10 @@
+import IconGrid from '../components/IconGrid';
+
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">TechJoint Tools</h1>
+      <IconGrid />
+    </main>
+  );
+}

--- a/tech-joint/src/routes/NotFound.tsx
+++ b/tech-joint/src/routes/NotFound.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Page Not Found</h1>
+    </main>
+  );
+}

--- a/tech-joint/src/routes/Tool.tsx
+++ b/tech-joint/src/routes/Tool.tsx
@@ -1,0 +1,10 @@
+import { useParams } from 'react-router-dom';
+
+export default function Tool() {
+  const { id } = useParams<{ id: string }>();
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Tool: {id}</h1>
+    </main>
+  );
+}

--- a/tech-joint/src/styles/globals.css
+++ b/tech-joint/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tech-joint/tailwind.config.ts
+++ b/tech-joint/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/tech-joint/tests/example.test.tsx
+++ b/tech-joint/tests/example.test.tsx
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('example test', () => {
+  it('works', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/tech-joint/tsconfig.json
+++ b/tech-joint/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tech-joint/tsconfig.node.json
+++ b/tech-joint/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/tech-joint/vite.config.ts
+++ b/tech-joint/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/tech-joint/',
+  plugins: [react()],
+});

--- a/tech-joint/vitest.config.ts
+++ b/tech-joint/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- setup Vite+React project in `tech-joint/`
- add devcontainer config and GitHub Actions deploy workflow
- scaffold basic components, routes and utilities
- include lint/test configs and example data
- document development instructions

## Testing
- `pnpm install --no-frozen-lockfile` *(fails: EHOSTUNREACH)*
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: ESLint config not found)*